### PR TITLE
参加方法がconnpassに変わったので、案内文を合わせて変更。

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
     </section>
     <section>
       <h2>参加方法</h2>
-      <p>希望の参加日のイベントページ(Facebook)で、参加表明します。参加する小中学生の学年、やりたいことをイベントページのタイムラインに書き込んでおいてください。受け入れ人数は最大5〜7人程度です。イベントページに詳細および注意事項が掲載してあります。参加前に確認してください。</p>
+      <p><a href="http://coderdojo-tokyo.connpass.com/">connpassのイベントページ</a>から参加申し込みします。受入人数は最大6人程度です。イベントページに詳細および注意事項が掲載してあります。参加前に確認してください。</p>
     </section>
     <section class="mentor" ng-controller="MentorController as mctrl">
       <h2>こんなひとたちがやってます</h2>


### PR DESCRIPTION
参加方法が旧来のFacebookイベントのままだったので、connpassからの参加申し込みへ文言とリンクを変更しました。
